### PR TITLE
add dry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ dry: false
 
 to your config.
 
+## The `HEARTBEAT_LOG` environment variable
+
+If you want `heartbeat` to log somewhere else than to
+`$WHERE_THE_BINARY_IS/../log` the set this environment
+variable:
+
+```shell
+HEARTBEAT_LOG=/var/log/heartbeat/log
+```
+
+or
+
+```shell
+HEARTBEAT_LOG=STDOUT
+```
+
 ## Reboots, shutdowns and planned maintenance
 
 If you do planned maintenance and you have to shutdown or reboot your server,

--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ to your config. Using this option, heartbeat will run only one check instead
 of running into a loop to continously run the checks. After the check,
 heartbeat will terminate.
 
+## The `dry` option
+
+If you want the `heartbeat` to neither trigger an IP failover nor to
+run the hooks, but just to tell you what it *would* do, then add
+
+```yaml
+dry: false
+```
+
+to your config.
+
 ## Reboots, shutdowns and planned maintenance
 
 If you do planned maintenance and you have to shutdown or reboot your server,

--- a/bin/heartbeat
+++ b/bin/heartbeat
@@ -21,7 +21,12 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-$logger = Logger.new(File.expand_path("../../log/heartbeat.log", __FILE__), 3, 10_485_760)
+$logger = if ENV['HEARTBEAT_LOG'] == "STDOUT"
+            Logger.new(STDOUT)
+          else
+            logfile = ENV['HEARTBEAT_LOG'] || File.expand_path("../../log/heartbeat.log", __FILE__)
+            Logger.new(logfile, 3, 10_485_760)
+          end
 
 threads = Dir.glob(options[:config]).collect do |path|
   Thread.new path do |file|

--- a/config/heartbeat.yml
+++ b/config/heartbeat.yml
@@ -23,3 +23,4 @@ timeout: 10
 
 tries: 3
 
+dry: false

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -39,6 +39,7 @@ class FailoverIp
     active_server_ip
   rescue
     $logger.error "Unable to retrieve the active server ip for #{failover_ip} from #{base_url}/failover/#{failover_ip}"
+    $logger.error "Response from Hetzner Robot API was: #{response}"
 
     nil
   end
@@ -81,7 +82,8 @@ class FailoverIp
       Hooks.run_before failover_ip, old_target, new_ip[:target], dry
 
       if !dry
-        raise unless HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth).success?
+        response = HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth).success?
+        raise unless response.success?
         $logger.info "Switch #{failover_ip} to #{new_ip[:target]} completed"
       else
         $logger.info "Dry run: would have switched #{failover_ip} to #{new_ip[:target]}"
@@ -95,6 +97,7 @@ class FailoverIp
     false
   rescue
     $logger.error "Unable to set a new active server ip for #{failover_ip} via POST to #{base_url}/failover/#{failover_ip}, :body => { :active_server_ip => #{new_ip[:target]} }, :basic_auth => #{basic_auth}"
+    $logger.error "Response from Hetzner Robot API was: #{response}"
 
     false
   end

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -82,7 +82,7 @@ class FailoverIp
       Hooks.run_before failover_ip, old_target, new_ip[:target], dry
 
       if !dry
-        response = HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth).success?
+        response = HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth)
         raise unless response.success?
         $logger.info "Switch #{failover_ip} to #{new_ip[:target]} completed"
       else

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -56,7 +56,12 @@ class FailoverIp
       (ips.size - 1).times do |i|
         ip = ips[(index + i + 1) % ips.size]
 
-        return ip if ping(ip[:ping])
+        if ping(ip[:ping])
+          return ip
+        else
+          $logger.info "Not selecting #{ip[:target]} to switch to since it doesn't ping on #{ip[:ping]}"
+        end
+
       end
     end
 

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -75,6 +75,7 @@ class FailoverIp
 
       if !dry
         raise unless HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth).success?
+        $logger.info "Switch #{failover_ip} to #{new_ip[:target]} completed"
       else
         $logger.info "Dry run: would have switched #{failover_ip} to #{new_ip[:target]}"
       end

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -36,7 +36,7 @@ class FailoverIp
 
     response.parsed_response.deep_symbolize_keys[:failover][:active_server_ip]
   rescue
-    $logger.error "Unable to retrieve the active server ip for #{failover_ip}"
+    $logger.error "Unable to retrieve the active server ip for #{failover_ip} from #{base_url}/failover/#{failover_ip}"
 
     nil
   end
@@ -86,7 +86,7 @@ class FailoverIp
 
     false
   rescue
-    $logger.error "Unable to set a new active server ip for #{failover_ip}"
+    $logger.error "Unable to set a new active server ip for #{failover_ip} via POST to #{base_url}/failover/#{failover_ip}, :body => { :active_server_ip => #{new_ip[:target]} }, :basic_auth => #{basic_auth}"
 
     false
   end

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -5,7 +5,7 @@ require "lib/hooks"
 require "hashr"
 
 class FailoverIp
-  attr_accessor :base_url, :basic_auth, :failover_ip, :ping_ip, :ips, :interval, :timeout, :tries, :force_down, :only_once
+  attr_accessor :base_url, :basic_auth, :failover_ip, :ping_ip, :ips, :interval, :timeout, :tries, :force_down, :only_once, :dry
 
   def ping(ip = ping_ip)
     tries.times.any? do |i|
@@ -71,11 +71,15 @@ class FailoverIp
 
       old_target = current_target
 
-      Hooks.run_before failover_ip, old_target, new_ip[:target]
+      Hooks.run_before failover_ip, old_target, new_ip[:target], dry
 
-      raise unless HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth).success?
+      if !dry
+        raise unless HTTParty.post("#{base_url}/failover/#{failover_ip}", :body => { :active_server_ip => new_ip[:target] }, :basic_auth => basic_auth).success?
+      else
+        $logger.info "Dry run: would have switched #{failover_ip} to #{new_ip[:target]}"
+      end
 
-      Hooks.run_after failover_ip, old_target, new_ip[:target]
+      Hooks.run_after failover_ip, old_target, new_ip[:target], dry
 
       return true
     end
@@ -98,6 +102,7 @@ class FailoverIp
     self.tries = options[:tries] || 3
     self.force_down = options[:force_down] || false
     self.only_once = options[:only_once] || false
+    self.dry = options[:dry] || false
   end
 
   def responsible_for?(ip)

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -34,7 +34,9 @@ class FailoverIp
 
     raise unless response.success?
 
-    response.parsed_response.deep_symbolize_keys[:failover][:active_server_ip]
+    active_server_ip = response.parsed_response.deep_symbolize_keys[:failover][:active_server_ip]
+    $logger.info "Ip of active server: #{active_server_ip}"
+    active_server_ip
   rescue
     $logger.error "Unable to retrieve the active server ip for #{failover_ip} from #{base_url}/failover/#{failover_ip}"
 

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -118,7 +118,7 @@ class FailoverIp
       if responsible_for?(current)
         switch_ips
       else
-        $logger.info "Not responsible for #{current}"
+        $logger.info "Not responsible for IP #{current}"
       end
 
       false

--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -1,17 +1,23 @@
 
 class Hooks
-  def self.run(kind, failover_ip, old_ip, new_ip)
+  def self.run(kind, failover_ip, old_ip, new_ip, dry)
     Dir[File.expand_path("../../hooks/#{kind}/*", __FILE__)].sort.each do |file|
-      system(file, failover_ip, old_ip, new_ip) if File.executable?(file)
+      if File.executable?(file)
+        if !dry
+          system(file, failover_ip, old_ip, new_ip)
+        else
+          $logger.info "Dry run: would have executed hook: system(#{file}, #{failover_ip}, #{old_ip}, #{new_ip})"
+        end
+      end
     end
   end
 
-  def self.run_before(failover_ip, old_ip, new_ip)
-    run "before", failover_ip, old_ip, new_ip
+  def self.run_before(failover_ip, old_ip, new_ip, dry)
+    run "before", failover_ip, old_ip, new_ip, dry
   end
 
-  def self.run_after(failover_ip, old_ip, new_ip)
-    run "after", failover_ip, old_ip, new_ip
+  def self.run_after(failover_ip, old_ip, new_ip, dry)
+    run "after", failover_ip, old_ip, new_ip, dry
   end
 end
 

--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -1,6 +1,6 @@
 
 class Hooks
-  def self.run(kind, failover_ip, old_ip, new_ip, dry)
+  def self.run(kind, failover_ip, old_ip, new_ip, dry = false)
     Dir[File.expand_path("../../hooks/#{kind}/*", __FILE__)].sort.each do |file|
       if File.executable?(file)
         if !dry
@@ -12,11 +12,11 @@ class Hooks
     end
   end
 
-  def self.run_before(failover_ip, old_ip, new_ip, dry)
+  def self.run_before(failover_ip, old_ip, new_ip, dry = false)
     run "before", failover_ip, old_ip, new_ip, dry
   end
 
-  def self.run_after(failover_ip, old_ip, new_ip, dry)
+  def self.run_after(failover_ip, old_ip, new_ip, dry = false)
     run "after", failover_ip, old_ip, new_ip, dry
   end
 end

--- a/test/failover_ip_test.rb
+++ b/test/failover_ip_test.rb
@@ -87,6 +87,21 @@ class FailoverIpTest < Test::Unit::TestCase
     end
   end
 
+  def test_switch_ips_dry
+    failover_ip = FailoverIp.new(:base_url => "https://robot-ws.your-server.de", :basic_auth => { :username => "username", :password => "password" }, :failover_ip => "0.0.0.0",
+      :ips => [{ :ping => "1.1.1.1", :target => "2.2.2.2" }, { :ping => "127.0.0.1", :target => "3.3.3.3" }], :dry => true )
+
+    set_current_target :failover_ip => failover_ip, :ip => "2.2.2.2"
+
+    assert_hooks_do_not_run "before" do
+      assert_no_switch(:failover_ip => failover_ip, :to => "3.3.3.3") { failover_ip.switch_ips }
+    end
+
+    assert_hooks_do_not_run "after" do
+      assert_no_switch(:failover_ip => failover_ip, :to => "3.3.3.3") { failover_ip.switch_ips }
+    end
+  end
+
   def test_check_with_failover
     failover_ip = FailoverIp.new(:base_url => "https://robot-ws.your-server.de", :basic_auth => { :username => "username", :password => "password" }, :failover_ip => "0.0.0.0",
       :ping_ip => "1.1.1.1", :ips => [{ :ping => "1.1.1.1", :target => "2.2.2.2" }, { :ping => "127.0.0.1", :target => "3.3.3.3" }])

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -14,5 +14,15 @@ class HooksTest < Test::Unit::TestCase
       Hooks.run_before "0.0.0.0", "1.1.1.1", "2.2.2.2"
     end
   end
+
+  def test_dry_run
+    assert_hooks_do_not_run "after" do
+      Hooks.run_after "0.0.0.0", "1.1.1.1", "2.2.2.2", true
+    end
+
+    assert_hooks_do_not_run "before" do
+      Hooks.run_before "0.0.0.0", "1.1.1.1", "2.2.2.2", true
+    end
+  end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,8 +9,7 @@ require "logger"
 $logger = Logger.new(File.expand_path("../../log/test.log", __FILE__))
 
 class Test::Unit::TestCase
-  def assert_hooks_run(kind)
-    hooks = File.expand_path("../../hooks", __FILE__)
+  def create_hooks(kind, hooks)
 
     open(File.join(hooks, kind, "hook1"), "w") do |stream|
       stream.write <<EOF
@@ -31,6 +30,16 @@ EOF
     end
 
     FileUtils.chmod 0755, File.join(hooks, kind, "hook2")
+  end
+
+  def remove_hooks(kind, hooks)
+      FileUtils.rm_f File.join(hooks, kind, "hook1")
+      FileUtils.rm_f File.join(hooks, kind, "hook2")
+  end
+
+  def assert_hooks_run(kind)
+    hooks = File.expand_path("../../hooks", __FILE__)
+    create_hooks
 
     begin
       yield
@@ -43,8 +52,7 @@ EOF
       assert File.exists?("/tmp/hook2.txt")
       assert File.read("/tmp/hook2.txt") =~ pattern
     ensure
-      FileUtils.rm_f File.join(hooks, kind, "hook1")
-      FileUtils.rm_f File.join(hooks, kind, "hook2")
+      remove_hooks(kind, hooks)
 
       FileUtils.rm_f "/tmp/hook1.txt"
       FileUtils.rm_f "/tmp/hook2.txt"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -99,6 +99,12 @@ EOF
     yield
   end
 
+  def assert_no_switch(options)
+    HTTParty.expects(:post).never()
+
+    yield
+  end
+
   def refute(boolean)
     assert !boolean
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,7 @@ EOF
 
   def assert_hooks_run(kind)
     hooks = File.expand_path("../../hooks", __FILE__)
-    create_hooks
+    create_hooks(kind, hooks)
 
     begin
       yield

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,6 +59,20 @@ EOF
     end
   end
 
+  def assert_hooks_do_not_run(kind)
+    hooks = File.expand_path("../../hooks", __FILE__)
+    create_hooks(kind, hooks)
+
+    begin
+      yield
+
+      assert !File.exist?("/tmp/hook1.txt")
+      assert !File.exist?("/tmp/hook2.txt")
+    ensure
+      remove_hooks(kind, hooks)
+    end
+  end
+
   def set_current_target(options)
     url = "#{options[:failover_ip].base_url}/failover/#{options[:failover_ip].failover_ip}"
 


### PR DESCRIPTION
Hi,

this pull request should implement #4 - the `dry` option. It also improves a few other things as error messages and logs more things.

I have *not* added tests for the `dry` option, nor have I verified whether the modified error messages and the additional logs pass the tests. I'd be nice to have a note in the documentation on how these tests are supposed to be run, then I'd could have a look:

```
bash-5.1# rake test
/usr/local/bin/ruby -w -I"lib:lib" /usr/local/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb "test/failover_ip_test.rb" "test/hooks_test.rb" 

File does not exist: test/unit

rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib" /usr/local/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb "test/failover_ip_test.rb" "test/hooks_test.rb" ]

Tasks: TOP => test
(See full trace by running task with --trace)
```

OT: I have tried to understand the failover_ip/ping_ip/ips: ping/target semantics by re-re-re-re-rereading the README and after that by studying the code, but I have not succeeded so far... a clearer README wrt to those semantics would be gold. 