### PR TITLE
feature: check Hetzner API before proceeding with monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ To configure the Hetzner API access, the Failover IP as well as your server's
 ip addresses, edit config/heartbeat.yml
 
 ```yaml
+
+# Should heartbeat try to access the Hetzner failover API
+# before starting the monitoring? This makes debugging your
+# system easier, since you will know from the start whether or not
+# heartbeat can access the API and not only when heartbeat needs
+# to access it to trigger a failover.
+#
+# This is off by default to preserve previous behavior but
+# probably shoud be on by default.
+#
+first_check_hetzner: true
+
 base_url: https://robot-ws.your-server.de
 
 basic_auth:

--- a/config/heartbeat.yml
+++ b/config/heartbeat.yml
@@ -1,5 +1,6 @@
-
 # Set your username and password to access the Hetzner API.
+
+first_check_hetzner: true
 
 base_url: https://robot-ws.your-server.de
 

--- a/config/shutdown.yml
+++ b/config/shutdown.yml
@@ -1,5 +1,6 @@
-
 # Set your username and password to access the Hetzner API.
+
+first_check_hetzner: true
 
 base_url: https://robot-ws.your-server.de
 

--- a/examples/config/heartbeat.yml
+++ b/examples/config/heartbeat.yml
@@ -1,5 +1,6 @@
-
 # Set your username and password to access the Hetzner API.
+
+first_check_hetzner: true
 
 base_url: https://robot-ws.your-server.de
 

--- a/lib/failover_ip.rb
+++ b/lib/failover_ip.rb
@@ -4,7 +4,7 @@ require "httparty"
 require "lib/hooks"
 
 class FailoverIp
-  attr_accessor :base_url, :basic_auth, :failover_ip, :ping_ip, :ips, :interval, :timeout, :tries, :force_down, :only_once, :dry
+  attr_accessor :first_check_hetzner, :attr_accessor, :base_url, :basic_auth, :failover_ip, :ping_ip, :ips, :interval, :timeout, :tries, :force_down, :only_once, :dry
 
   def ping(ip = ping_ip)
     tries.times.any? do |i|
@@ -102,6 +102,7 @@ class FailoverIp
   end
 
   def initialize(options)
+    self.first_check_hetzner = options[:first_check_hetzner] || false
     self.base_url = options[:base_url]
     self.basic_auth = options[:basic_auth]
     self.failover_ip = options[:failover_ip]
@@ -140,6 +141,11 @@ class FailoverIp
   end
 
   def monitor
+    if first_check_hetzner
+      $logger.info "Initial Hetzner API check."
+      current_target
+    end
+
     loop do
       res = check
 


### PR DESCRIPTION
Implements https://github.com/mrkamel/heartbeat/issues/16

Maybe the default could be changed to `first_check_hetzner: true`. This would however break previous behavior...